### PR TITLE
Error alerts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 ruby '2.2.2'
 
+gem 'sentry-raven', git: 'https://github.com/getsentry/raven-ruby.git'
+
 gemspec
 
 group :development, :test do

--- a/lib/optimus_prime.rb
+++ b/lib/optimus_prime.rb
@@ -7,6 +7,8 @@ require 'optimus_prime/step'
 require 'optimus_prime/source'
 require 'optimus_prime/destination'
 
+require 'optimus_prime/adapters/sentry_adapter.rb'
+
 require 'optimus_prime/sources/s3_source'
 require 'optimus_prime/destinations/rdbms_writer'
 require 'optimus_prime/sources/flurry_helpers/flurry_connector'

--- a/lib/optimus_prime.rb
+++ b/lib/optimus_prime.rb
@@ -7,6 +7,7 @@ require 'optimus_prime/step'
 require 'optimus_prime/source'
 require 'optimus_prime/destination'
 
+require 'optimus_prime/adapters/base_adapter.rb'
 require 'optimus_prime/adapters/sentry_adapter.rb'
 
 require 'optimus_prime/sources/s3_source'

--- a/lib/optimus_prime/adapters/base_adapter.rb
+++ b/lib/optimus_prime/adapters/base_adapter.rb
@@ -1,0 +1,27 @@
+module OptimusPrime
+  module Adapters
+
+    class BaseAdapter
+
+      def initialize(options)
+        configure_errors_adapter do |config|
+          options.each do |key, value|
+            config.send(key, value)
+          end
+        end
+      end
+
+      def run
+        raise 'Abstract Method.'
+      end
+
+      protected
+
+      def configure_errors_adapter
+        raise 'Abstract Method.'
+      end
+
+    end
+
+  end
+end

--- a/lib/optimus_prime/adapters/base_adapter.rb
+++ b/lib/optimus_prime/adapters/base_adapter.rb
@@ -6,7 +6,7 @@ module OptimusPrime
       def initialize(options)
         configure_errors_adapter do |config|
           options.each do |key, value|
-            config.send(key, value)
+            config.send("#{key}=", value)
           end
         end
       end

--- a/lib/optimus_prime/adapters/sentry_adapter.rb
+++ b/lib/optimus_prime/adapters/sentry_adapter.rb
@@ -1,10 +1,12 @@
+require 'sentry-raven'
+
 module OptimusPrime
   module Adapters
 
-    class SentryAdapter
+    class SentryAdapter < BaseAdapter
 
       def run(&block)
-        Raven.capture do
+        ::Raven.capture do
           block.call
         end
       end
@@ -12,7 +14,9 @@ module OptimusPrime
       private
 
       def configure_errors_adapter(&block)
-        Raven.configure(block)
+        ::Raven.configure do |config|
+          block.call(config)
+        end
       end
 
     end

--- a/lib/optimus_prime/adapters/sentry_adapter.rb
+++ b/lib/optimus_prime/adapters/sentry_adapter.rb
@@ -1,0 +1,21 @@
+module OptimusPrime
+  module Adapters
+
+    class SentryAdapter
+
+      def run(&block)
+        Raven.capture do
+          block.call
+        end
+      end
+
+      private
+
+      def configure_errors_adapter(&block)
+        Raven.configure(block)
+      end
+
+    end
+
+  end
+end

--- a/lib/optimus_prime/cli/pipeline_operator.rb
+++ b/lib/optimus_prime/cli/pipeline_operator.rb
@@ -21,7 +21,7 @@ module OptimusPrime
       end
 
       def operate
-        @errors_adapter ? @errors_adapter.run(method(:start_pipeline)) : start_pipeline
+        @errors_adapter ? @errors_adapter.run(&method(:start_pipeline)) : start_pipeline
       end
 
       def finished?

--- a/optimus_prime.gemspec
+++ b/optimus_prime.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'bigbroda',          '0.0.7'
   spec.add_dependency 'mail'
   spec.add_dependency 'thor'
+  spec.add_dependency 'sentry-raven'
 end

--- a/spec/optimus_binary_spec.rb
+++ b/spec/optimus_binary_spec.rb
@@ -16,6 +16,7 @@ Pipeline finished.
 
   let(:config_path) { 'spec/supports/config/test-config.yml' }
   let(:config_dependencies) { 'spec/supports/config/test-config-dependencies.yml' }
+  let(:config_exceptions) { 'spec/supports/config/test-config-exceptions.yml' }
 
   def tmp_destination
     @tmp_destination ||= 'tmp/destination.csv'
@@ -73,6 +74,13 @@ Pipeline finished.
           expect(@output).to include 'Requiring csv'
           expect(@output).to include 'Requiring benchmark'
         end
+      end
+    end
+
+    context 'with an exception adapter specified' do
+      it 'dfifou' do
+        @output = `#{operate} pipeline #{config_exceptions} test_pipeline`
+        expect(@output).to include finished
       end
     end
   end

--- a/spec/optimus_binary_spec.rb
+++ b/spec/optimus_binary_spec.rb
@@ -78,8 +78,9 @@ Pipeline finished.
     end
 
     context 'with an exception adapter specified' do
-      it 'dfifou' do
+      it 'starts to capture exceptions with Raven' do
         @output = `#{operate} pipeline #{config_exceptions} test_pipeline`
+        expect(@output).to include 'Raven'
         expect(@output).to include finished
       end
     end

--- a/spec/supports/config/test-config-exceptions.yml
+++ b/spec/supports/config/test-config-exceptions.yml
@@ -1,0 +1,34 @@
+# Using Ruby to set yaml values with a string and a lambda
+source1: &csv_source <%= 'spec/supports/csv/local_csv_source_sample.csv' %>
+source2: &pipe_source <%= -> { 'spec/supports/csv/local_csv_source_pipe.csv' }.call %>
+destination: &destination 'tmp/destination.csv'
+test_pipeline:
+
+  errors:
+    adapter: Sentry
+    options:
+      dsn: 'fifou'
+
+  dependencies:
+    - json
+    - csv
+
+  graph:
+    a:
+      class: 'OptimusPrime::Sources::LocalCsv'
+      params:
+        file_path: *csv_source
+      next:
+        - c
+    b:
+      class: 'OptimusPrime::Sources::LocalCsv'
+      params:
+        file_path: *pipe_source
+        col_sep: '|'
+      next:
+        - c
+    c:
+      class: 'OptimusPrime::Destinations::LocalCsv'
+      params:
+        fields: ['FirstName', 'LastName', 'Title', 'ReportsTo.Email', 'Birthdate', 'Description']
+        file_path: *destination

--- a/spec/supports/config/test-config-exceptions.yml
+++ b/spec/supports/config/test-config-exceptions.yml
@@ -7,11 +7,7 @@ test_pipeline:
   errors:
     adapter: Sentry
     options:
-      dsn: 'fifou'
-
-  dependencies:
-    - json
-    - csv
+      dsn: 'test'
 
   graph:
     a:


### PR DESCRIPTION
This Pull Request adds a way to handle exceptions with external services. For now, it only supports `Sentry` but adding more adapters is easy. 

The config inside a pipeline looks like this:

```
errors:
  adapter: Sentry
  options:
    dsn: 'your_dsn_url'
```

All the `options` will be passed to the configuration block of the exception handling gem. In Sentry case, it's [sentry-raven](https://github.com/getsentry/raven-ruby).
