### PR TITLE
BigQuery Nested-Fields String Transformer

### DIFF
--- a/lib/optimus_prime/transformers/bigquery_nested_fields_string_converter.rb
+++ b/lib/optimus_prime/transformers/bigquery_nested_fields_string_converter.rb
@@ -6,20 +6,20 @@ module OptimusPrime
     # one level nested-fields string to an array of hash
     # for preparing data before inserting into Google BigQuery.
     #
-    # Example: 
+    # Example:
     # - record:
     #  {
-    #    "field1" => "value",
-    #    "field2" => "{\"id\":298,\"type\":\"sms\",\"cost\":2}\n",
-    #    "field3" => "{\"id\":299,\"type\":\"mms\",\"cost\":5}\n"
+    #    'field1' => 'value',
+    #    'field2' => "{\"id\":298,\"type\":\"sms\",\"cost\":2}\n",
+    #    'field3' => "{\"id\":299,\"type\":\"mms\",\"cost\":5}\n"
     #  }
     # - keys: ["field2", "field3"]
     #
     # - output:
     #  {
-    #    "field1" => "value",
-    #    "field2" => [{"id"=>298, "type"=>"sms", "cost"=>2}],
-    #    "field3" => [{"id"=>299, "type"=>"mms", "cost"=>5}]
+    #    'field1' => 'value',
+    #    'field2' => [{ 'id' => 298, 'type' => 'sms', 'cost' => 2 }],
+    #    'field3' => [{ 'id' => 299, 'type' => 'mms', 'cost' => 5 }]
     #  }
     class BigQueryNestedFieldsStringConverter < Destination
       def initialize(keys:)
@@ -34,7 +34,7 @@ module OptimusPrime
 
       def convert(record)
         @keys.each do |key|
-          record[key] = [JSON.parse(record[key])]
+          record[key] = [JSON.parse(record[key])] if record.key?(key)
         end
         record
       end

--- a/lib/optimus_prime/transformers/bigquery_nested_fields_string_converter.rb
+++ b/lib/optimus_prime/transformers/bigquery_nested_fields_string_converter.rb
@@ -1,0 +1,43 @@
+require 'json'
+
+module OptimusPrime
+  module Transformers
+    # This class accepts a hash object and converts
+    # one level nested-fields string to an array of hash
+    # for preparing data before inserting into Google BigQuery.
+    #
+    # Example: 
+    # - record:
+    #  {
+    #    "field1" => "value",
+    #    "field2" => "{\"id\":298,\"type\":\"sms\",\"cost\":2}\n",
+    #    "field3" => "{\"id\":299,\"type\":\"mms\",\"cost\":5}\n"
+    #  }
+    # - keys: ["field2", "field3"]
+    #
+    # - output:
+    #  {
+    #    "field1" => "value",
+    #    "field2" => [{"id"=>298, "type"=>"sms", "cost"=>2}],
+    #    "field3" => [{"id"=>299, "type"=>"mms", "cost"=>5}]
+    #  }
+    class BigQueryNestedFieldsStringConverter < Destination
+      def initialize(keys:)
+        @keys = keys
+      end
+
+      def write(record)
+        push convert(record)
+      end
+
+      private
+
+      def convert(record)
+        @keys.each do |key|
+          record[key] = [JSON.parse(record[key])]
+        end
+        record
+      end
+    end
+  end
+end

--- a/lib/optimus_prime/transformers/bigquery_nested_fields_string_converter.rb
+++ b/lib/optimus_prime/transformers/bigquery_nested_fields_string_converter.rb
@@ -21,7 +21,7 @@ module OptimusPrime
     #    'field2' => [{ 'id' => 298, 'type' => 'sms', 'cost' => 2 }],
     #    'field3' => [{ 'id' => 299, 'type' => 'mms', 'cost' => 5 }]
     #  }
-    class BigQueryNestedFieldsStringConverter < Destination
+    class BigqueryNestedFieldsStringConverter < Destination
       def initialize(keys:)
         @keys = keys
       end

--- a/spec/optimus_prime/transformers/bigquery_nested_fields_string_converter_spec.rb
+++ b/spec/optimus_prime/transformers/bigquery_nested_fields_string_converter_spec.rb
@@ -4,12 +4,12 @@ require 'optimus_prime/transformers/bigquery_nested_fields_string_converter'
 module OptimusPrime
   module Sources
     class MySource < Source
-      def initialize(events:)
-        @events = events
+      def initialize(records:)
+        @records = records
       end
 
       def each
-        @events.each { |event| yield event }
+        @records.each { |record| yield record }
       end
     end
   end
@@ -29,19 +29,19 @@ module OptimusPrime
 end
 
 describe OptimusPrime::Transformers::BigQueryNestedFieldsStringConverter do
-  let(:inputs) do
+  let(:input) do
     [
       {
-        "field1" => "value",
-        "field2" => "{\"customer_id\":298,\"type\":\"sms\",\"cost\":2}\n",
-        "field3" => "{\"customer_id\":298,\"type\":\"mms\",\"cost\":5}\n"
+        'field1' => 'value',
+        'field2' => "{\"customer_id\":298,\"type\":\"sms\",\"cost\":2}\n",
+        'field3' => "{\"customer_id\":298,\"type\":\"mms\",\"cost\":5}\n"
       },
       {
-        "field1" => "value",
-        "field2" => "{\"customer_id\":555,\"type\":\"sms\",\"cost\":2}\n"
+        'field1' => 'value',
+        'field2' => "{\"customer_id\":555,\"type\":\"sms\",\"cost\":2}\n"
       },
       {
-        "field1" => "value"
+        'field1' => 'value'
       }
     ]
   end
@@ -49,43 +49,40 @@ describe OptimusPrime::Transformers::BigQueryNestedFieldsStringConverter do
   let(:output) do
     [
       {
-        "field1" => "value",
-        "field2" => [{ "customer_id"=>298, "type"=>"sms", "cost"=>2 }],
-        "field3" => [{ "customer_id"=>298, "type"=>"mms", "cost"=>5 }]
+        'field1' => 'value',
+        'field2' => [{ 'customer_id' => 298, 'type' => 'sms', 'cost' => 2 }],
+        'field3' => [{ 'customer_id' => 298, 'type' => 'mms', 'cost' => 5 }]
       },
       {
-        "field1" => "value",
-        "field2" => [{ "customer_id"=>555, "type"=>"sms", "cost"=>2 }]
+        'field1' => 'value',
+        'field2' => [{ 'customer_id' => 555, 'type' => 'sms', 'cost' => 2 }]
       },
       {
-        "field1" =>  "value"
+        'field1' =>  'value'
       }
     ]
   end
 
-  let(:sources) do
-    Hash[inputs.map.with_index do |input, idx|
-      ["src_#{idx}".to_sym, {
-        class: 'OptimusPrime::Sources::MySource',
-        params: { events: input },
-        next: ['trans_c']
-      }]
-    end]
-  end
-
   let(:pipeline) do
-    OptimusPrime::Pipeline.new(**{
-      trans_c: {
-        class: 'OptimusPrime::Transformers::BigQueryNestedFieldsStringConverter',
-        params: { join_keys: [:Platform, :Level] },
-        next: ['dest_d']
-      },
-      dest_d: { class: 'OptimusPrime::Destinations::MyDestination' }
-    }.merge(sources))
+    OptimusPrime::Pipeline.new(
+      **{
+        src: {
+          class: 'OptimusPrime::Sources::MySource',
+          params: { records: input },
+          next: ['trans']
+        },
+        trans: {
+          class: 'OptimusPrime::Transformers::BigQueryNestedFieldsStringConverter',
+          params: { keys: ['field2', 'field3'] },
+          next: ['dest']
+        },
+        dest: { class: 'OptimusPrime::Destinations::MyDestination' }
+      }
+    )
   end
 
   it 'converts one level nested-fields string to an array of hash' do
-    results = pipeline.start.wait.steps[:dest_d].written
+    results = pipeline.start.wait.steps[:dest].written
     expect(results).to match_array output
   end
 end

--- a/spec/optimus_prime/transformers/bigquery_nested_fields_string_converter_spec.rb
+++ b/spec/optimus_prime/transformers/bigquery_nested_fields_string_converter_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+require 'optimus_prime/transformers/bigquery_nested_fields_string_converter'
+
+module OptimusPrime
+  module Sources
+    class MySource < Source
+      def initialize(events:)
+        @events = events
+      end
+
+      def each
+        @events.each { |event| yield event }
+      end
+    end
+  end
+
+  module Destinations
+    class MyDestination < Destination
+      attr_reader :written
+      def initialize
+        @written = []
+      end
+
+      def write(record)
+        @written << record
+      end
+    end
+  end
+end
+
+describe OptimusPrime::Transformers::BigQueryNestedFieldsStringConverter do
+  let(:inputs) do
+    [
+      {
+        "field1" => "value",
+        "field2" => "{\"customer_id\":298,\"type\":\"sms\",\"cost\":2}\n",
+        "field3" => "{\"customer_id\":298,\"type\":\"mms\",\"cost\":5}\n"
+      },
+      {
+        "field1" => "value",
+        "field2" => "{\"customer_id\":555,\"type\":\"sms\",\"cost\":2}\n"
+      },
+      {
+        "field1" => "value"
+      }
+    ]
+  end
+
+  let(:output) do
+    [
+      {
+        "field1" => "value",
+        "field2" => [{ "customer_id"=>298, "type"=>"sms", "cost"=>2 }],
+        "field3" => [{ "customer_id"=>298, "type"=>"mms", "cost"=>5 }]
+      },
+      {
+        "field1" => "value",
+        "field2" => [{ "customer_id"=>555, "type"=>"sms", "cost"=>2 }]
+      },
+      {
+        "field1" =>  "value"
+      }
+    ]
+  end
+
+  let(:sources) do
+    Hash[inputs.map.with_index do |input, idx|
+      ["src_#{idx}".to_sym, {
+        class: 'OptimusPrime::Sources::MySource',
+        params: { events: input },
+        next: ['trans_c']
+      }]
+    end]
+  end
+
+  let(:pipeline) do
+    OptimusPrime::Pipeline.new(**{
+      trans_c: {
+        class: 'OptimusPrime::Transformers::BigQueryNestedFieldsStringConverter',
+        params: { join_keys: [:Platform, :Level] },
+        next: ['dest_d']
+      },
+      dest_d: { class: 'OptimusPrime::Destinations::MyDestination' }
+    }.merge(sources))
+  end
+
+  it 'converts one level nested-fields string to an array of hash' do
+    results = pipeline.start.wait.steps[:dest_d].written
+    expect(results).to match_array output
+  end
+end

--- a/spec/optimus_prime/transformers/bigquery_nested_fields_string_converter_spec.rb
+++ b/spec/optimus_prime/transformers/bigquery_nested_fields_string_converter_spec.rb
@@ -32,16 +32,10 @@ describe OptimusPrime::Transformers::BigqueryNestedFieldsStringConverter do
   def init_pipeline(keys:)
     OptimusPrime::Pipeline.new(
       **{
-        src: {
-          class: 'OptimusPrime::Sources::MyTestSource',
-          params: { records: input },
-          next: ['trans']
-        },
-        trans: {
-          class: 'OptimusPrime::Transformers::BigqueryNestedFieldsStringConverter',
-          params: { keys: keys },
-          next: ['dest']
-        },
+        src: { class: 'OptimusPrime::Sources::MyTestSource',
+               params: { records: input }, next: ['trans'] },
+        trans: { class: 'OptimusPrime::Transformers::BigqueryNestedFieldsStringConverter',
+                 params: { keys: keys }, next: ['dest'] },
         dest: { class: 'OptimusPrime::Destinations::MyTestDestination' }
       }
     )
@@ -107,7 +101,7 @@ describe OptimusPrime::Transformers::BigqueryNestedFieldsStringConverter do
         {
           field1: 'value',
           field2: [{ 'customer_id' => 298, 'type' => 'sms', 'cost' => 2 }],
-          field3: [{ :customer_id => 298, :type => 'mms', :cost => 5 }]
+          field3: [{ customer_id: 298, type: 'mms', cost: 5 }]
         },
         {
           field1: 'value'

--- a/spec/optimus_prime/transformers/bigquery_nested_fields_string_converter_spec.rb
+++ b/spec/optimus_prime/transformers/bigquery_nested_fields_string_converter_spec.rb
@@ -3,7 +3,7 @@ require 'optimus_prime/transformers/bigquery_nested_fields_string_converter'
 
 module OptimusPrime
   module Sources
-    class MySource < Source
+    class MyTestSource < Source
       def initialize(records:)
         @records = records
       end
@@ -15,7 +15,7 @@ module OptimusPrime
   end
 
   module Destinations
-    class MyDestination < Destination
+    class MyTestDestination < Destination
       attr_reader :written
       def initialize
         @written = []
@@ -28,7 +28,7 @@ module OptimusPrime
   end
 end
 
-describe OptimusPrime::Transformers::BigQueryNestedFieldsStringConverter do
+describe OptimusPrime::Transformers::BigqueryNestedFieldsStringConverter do
   let(:input) do
     [
       {
@@ -67,16 +67,16 @@ describe OptimusPrime::Transformers::BigQueryNestedFieldsStringConverter do
     OptimusPrime::Pipeline.new(
       **{
         src: {
-          class: 'OptimusPrime::Sources::MySource',
+          class: 'OptimusPrime::Sources::MyTestSource',
           params: { records: input },
           next: ['trans']
         },
         trans: {
-          class: 'OptimusPrime::Transformers::BigQueryNestedFieldsStringConverter',
+          class: 'OptimusPrime::Transformers::BigqueryNestedFieldsStringConverter',
           params: { keys: ['field2', 'field3'] },
           next: ['dest']
         },
-        dest: { class: 'OptimusPrime::Destinations::MyDestination' }
+        dest: { class: 'OptimusPrime::Destinations::MyTestDestination' }
       }
     )
   end

--- a/spec/optimus_prime/transformers/bigquery_nested_fields_string_converter_spec.rb
+++ b/spec/optimus_prime/transformers/bigquery_nested_fields_string_converter_spec.rb
@@ -29,41 +29,7 @@ module OptimusPrime
 end
 
 describe OptimusPrime::Transformers::BigqueryNestedFieldsStringConverter do
-  let(:input) do
-    [
-      {
-        'field1' => 'value',
-        'field2' => "{\"customer_id\":298,\"type\":\"sms\",\"cost\":2}\n",
-        'field3' => "{\"customer_id\":298,\"type\":\"mms\",\"cost\":5}\n"
-      },
-      {
-        'field1' => 'value',
-        'field2' => "{\"customer_id\":555,\"type\":\"sms\",\"cost\":2}\n"
-      },
-      {
-        'field1' => 'value'
-      }
-    ]
-  end
-
-  let(:output) do
-    [
-      {
-        'field1' => 'value',
-        'field2' => [{ 'customer_id' => 298, 'type' => 'sms', 'cost' => 2 }],
-        'field3' => [{ 'customer_id' => 298, 'type' => 'mms', 'cost' => 5 }]
-      },
-      {
-        'field1' => 'value',
-        'field2' => [{ 'customer_id' => 555, 'type' => 'sms', 'cost' => 2 }]
-      },
-      {
-        'field1' =>  'value'
-      }
-    ]
-  end
-
-  let(:pipeline) do
+  def init_pipeline(keys:)
     OptimusPrime::Pipeline.new(
       **{
         src: {
@@ -73,7 +39,7 @@ describe OptimusPrime::Transformers::BigqueryNestedFieldsStringConverter do
         },
         trans: {
           class: 'OptimusPrime::Transformers::BigqueryNestedFieldsStringConverter',
-          params: { keys: ['field2', 'field3'] },
+          params: { keys: keys },
           next: ['dest']
         },
         dest: { class: 'OptimusPrime::Destinations::MyTestDestination' }
@@ -81,8 +47,77 @@ describe OptimusPrime::Transformers::BigqueryNestedFieldsStringConverter do
     )
   end
 
-  it 'converts one level nested-fields string to an array of hash' do
-    results = pipeline.start.wait.steps[:dest].written
-    expect(results).to match_array output
+  context 'input hash has string keys' do
+    let(:input) do
+      [
+        {
+          'field1' => 'value',
+          'field2' => "{\"customer_id\":298,\"type\":\"sms\",\"cost\":2}\n",
+          'field3' => "{\"customer_id\":298,\"type\":\"mms\",\"cost\":5}\n"
+        },
+        {
+          'field1' => 'value',
+          'field2' => "{\"customer_id\":555,\"type\":\"sms\",\"cost\":2}\n"
+        },
+        {
+          'field1' => 'value'
+        }
+      ]
+    end
+
+    let(:output) do
+      [
+        {
+          'field1' => 'value',
+          'field2' => [{ 'customer_id' => 298, 'type' => 'sms', 'cost' => 2 }],
+          'field3' => [{ 'customer_id' => 298, 'type' => 'mms', 'cost' => 5 }]
+        },
+        {
+          'field1' => 'value',
+          'field2' => [{ 'customer_id' => 555, 'type' => 'sms', 'cost' => 2 }]
+        },
+        {
+          'field1' =>  'value'
+        }
+      ]
+    end
+
+    it 'converts one level nested-fields string to an array of hash' do
+      results = init_pipeline(keys: ['field2', 'field3']).start.wait.steps[:dest].written
+      expect(results).to match_array output
+    end
+  end
+
+  context 'input hash has symbol keys' do
+    let(:input) do
+      [
+        {
+          field1: 'value',
+          field2: "{\"customer_id\":298,\"type\":\"sms\",\"cost\":2}\n",
+          field3: "{\"customer_id\":298,\"type\":\"mms\",\"cost\":5}\n"
+        },
+        {
+          field1: 'value'
+        }
+      ]
+    end
+
+    let(:output) do
+      [
+        {
+          field1: 'value',
+          field2: [{ 'customer_id' => 298, 'type' => 'sms', 'cost' => 2 }],
+          field3: [{ :customer_id => 298, :type => 'mms', :cost => 5 }]
+        },
+        {
+          field1: 'value'
+        }
+      ]
+    end
+
+    it 'converts one level nested-fields string to an array of hash' do
+      results = init_pipeline(keys: [:field2, :field3]).start.wait.steps[:dest].written
+      expect(results).to match_array output
+    end
   end
 end


### PR DESCRIPTION
This class accepts a hash object and converts one level nested-fields string to an array of hash for preparing data before inserting into Google BigQuery.
### Example:
#### record:

```
{
  'field1' => 'value',
  'field2' => "{\"id\":298,\"type\":\"sms\",\"cost\":2}\n",
  'field3' => "{\"id\":299,\"type\":\"mms\",\"cost\":5}\n"
}
```
#### keys:

```
["field2", "field3"]
```
#### output:

```
{
  'field1' => 'value',
  'field2' => [{ 'id' => 298, 'type' => 'sms', 'cost' => 2 }],
  'field3' => [{ 'id' => 299, 'type' => 'mms', 'cost' => 5 }]
}
```
