### PR TITLE
Add ability to retrieve AppAnnie product sales data

### DIFF
--- a/lib/optimus_prime.rb
+++ b/lib/optimus_prime.rb
@@ -14,6 +14,7 @@ require 'optimus_prime/sources/s3_source'
 require 'optimus_prime/destinations/rdbms_writer'
 require 'optimus_prime/sources/flurry_helpers/flurry_connector'
 require 'optimus_prime/transformers/expand_json'
+require 'optimus_prime/sources/app_annie'
 
 # Load all Sources and Destinations
 Dir[File.dirname(__FILE__) + '/optimus_prime/**/*.rb'].each do |file|

--- a/lib/optimus_prime/sources/app_annie.rb
+++ b/lib/optimus_prime/sources/app_annie.rb
@@ -1,0 +1,19 @@
+require 'json'
+require 'rest_client'
+
+module OptimusPrime
+  module Sources
+    class AppAnnie < OptimusPrime::Source
+      def request(method:, path:, api_key:, **options)
+        url = "https://api.appannie.com#{path}"
+        begin
+          response = JSON.parse(
+            RestClient.send(method, url, ({ authorization: "Bearer #{api_key}" }).merge(options))
+          )
+        rescue => e
+          raise e.response
+        end
+      end
+    end
+  end
+end

--- a/lib/optimus_prime/sources/app_annie.rb
+++ b/lib/optimus_prime/sources/app_annie.rb
@@ -7,7 +7,7 @@ module OptimusPrime
       def request(method:, path:, api_key:, **options)
         url = "https://api.appannie.com#{path}"
         begin
-          response = JSON.parse(
+          JSON.parse(
             RestClient.send(method, url, ({ authorization: "Bearer #{api_key}" }).merge(options))
           )
         rescue => e

--- a/lib/optimus_prime/sources/app_annie_product_sales.rb
+++ b/lib/optimus_prime/sources/app_annie_product_sales.rb
@@ -6,11 +6,11 @@
 module OptimusPrime
   module Sources
     class AppAnnieProductSales < AppAnnie
-      def initialize(api_key:, account_id:, product_id:, start_date:, end_date:, **options)
+      def initialize(api_key:, account_id:, product_id:,
+                     start_date:, end_date:, **options)
         @api_key = api_key
         @path = "/v1.2/accounts/#{account_id}/products/#{product_id}/sales"
-        @params = { params: options.merge({ start_date: start_date,
-                                            end_date: end_date }) }
+        @params = { params: options.merge(start_date: start_date, end_date: end_date) }
       end
 
       def each

--- a/lib/optimus_prime/sources/app_annie_product_sales.rb
+++ b/lib/optimus_prime/sources/app_annie_product_sales.rb
@@ -1,0 +1,38 @@
+# The AppAnnieProductSales source retrieves the sales data for a single product.
+#
+# You can pass optional parameters via "options".
+# For more details see http://support.appannie.com/hc/en-us/articles/204208914-3-Product-Sales-.
+
+module OptimusPrime
+  module Sources
+    class AppAnnieProductSales < AppAnnie
+      def initialize(api_key:, account_id:, product_id:, start_date:, end_date:, **options)
+        @api_key = api_key
+        @path = "/v1.2/accounts/#{account_id}/products/#{product_id}/sales"
+        @params = { params: options.merge({ start_date: start_date,
+                                            end_date: end_date }) }
+      end
+
+      def each
+        request(method: :get, path: @path, api_key: @api_key, **@params).each do |response|
+          yield response
+        end
+      end
+
+      private
+
+      def request(method:, path:, api_key:, **options)
+        Enumerator.new do |enum|
+          loop do
+            response = super
+            enum << response
+            break unless response['next_page']
+
+            path = response['next_page']
+            options = {}
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/optimus_prime/sources/app_annie_product_sales_spec.rb
+++ b/spec/optimus_prime/sources/app_annie_product_sales_spec.rb
@@ -20,15 +20,17 @@ describe OptimusPrime::Sources::AppAnnieProductSales do
   describe '#each' do
     let(:pipeline) do
       OptimusPrime::Pipeline.new(
-        src: { class: 'OptimusPrime::Sources::AppAnnieProductSales',
-               params: {
-                  api_key: 'api_key',
-                  account_id: 'acc_id',
-                  product_id: 'prod_id',
-                  start_date: '2015-01-01',
-                  end_date: '2015-01-01',
-                  break_down: 'date+country+iap'
-               }, next: ['dest'] },
+        src: {
+          class: 'OptimusPrime::Sources::AppAnnieProductSales',
+          params: {
+            api_key: 'api_key',
+            account_id: 'acc_id',
+            product_id: 'prod_id',
+            start_date: '2015-01-01',
+            end_date: '2015-01-01',
+            break_down: 'date+country+iap'
+          }, next: ['dest']
+        },
         dest: { class: 'OptimusPrime::Destinations::MyTestDestination' }
       )
     end
@@ -38,20 +40,22 @@ describe OptimusPrime::Sources::AppAnnieProductSales do
     let(:response_body_2) { File.read('spec/supports/app_annie/response_2.json') }
 
     def stub_request_app_annie(body, params)
-      stub_request(:get,
-        "https://api.appannie.com/v1.2/accounts/acc_id/products/prod_id/sales?#{params}").
-        with(:headers => {
-          'Accept'=>'*/*; q=0.5, application/xml',
-          'Accept-Encoding'=>'gzip, deflate',
-          'Authorization'=>'Bearer api_key',
-          'User-Agent'=>'Ruby'
-        }).to_return(:status => 200, :body => body, :headers => {})
+      url = "https://api.appannie.com/v1.2/accounts/acc_id/products/prod_id/sales?#{params}"
+      stub_request(:get, url).with(
+        headers: {
+          'Accept' => '*/*; q=0.5, application/xml',
+          'Accept-Encoding' => 'gzip, deflate',
+          'Authorization' => 'Bearer api_key',
+          'User-Agent' => 'Ruby'
+        }).to_return(status: 200, body: body, headers: {})
     end
 
     context 'one page response' do
       it 'returns reponse body' do
-        stub_request_app_annie(response_body,
-          'break_down=date%2Bcountry%2Biap&end_date=2015-01-01&start_date=2015-01-01')
+        stub_request_app_annie(
+          response_body,
+          'break_down=date%2Bcountry%2Biap&end_date=2015-01-01&start_date=2015-01-01'
+        )
 
         results = pipeline.start.wait.steps[:dest].written
         expect(results).to match_array [JSON.parse(response_body)]
@@ -60,10 +64,14 @@ describe OptimusPrime::Sources::AppAnnieProductSales do
 
     context 'multiple pages response' do
       it 'returns response body' do
-        stub_request_app_annie(response_body_1,
-          'break_down=date%2Bcountry%2Biap&end_date=2015-01-01&start_date=2015-01-01')
-        stub_request_app_annie(response_body_2,
-          'break_down=date%20country%20iap&end_date=2015-01-01&page_index=1&start_date=2015-01-01')
+        stub_request_app_annie(
+          response_body_1,
+          'break_down=date%2Bcountry%2Biap&end_date=2015-01-01&start_date=2015-01-01'
+        )
+        stub_request_app_annie(
+          response_body_2,
+          'break_down=date%20country%20iap&end_date=2015-01-01&page_index=1&start_date=2015-01-01'
+        )
 
         results = pipeline.start.wait.steps[:dest].written
         expect(results).to match_array [JSON.parse(response_body_1), JSON.parse(response_body_2)]

--- a/spec/optimus_prime/sources/app_annie_product_sales_spec.rb
+++ b/spec/optimus_prime/sources/app_annie_product_sales_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+require 'optimus_prime/sources/app_annie_product_sales'
+
+module OptimusPrime
+  module Destinations
+    class MyTestDestination < Destination
+      attr_reader :written
+      def initialize
+        @written = []
+      end
+
+      def write(record)
+        @written << record
+      end
+    end
+  end
+end
+
+describe OptimusPrime::Sources::AppAnnieProductSales do
+  describe '#each' do
+    let(:pipeline) do
+      OptimusPrime::Pipeline.new(
+        src: { class: 'OptimusPrime::Sources::AppAnnieProductSales',
+               params: {
+                  api_key: 'api_key',
+                  account_id: 'acc_id',
+                  product_id: 'prod_id',
+                  start_date: '2015-01-01',
+                  end_date: '2015-01-01',
+                  break_down: 'date+country+iap'
+               }, next: ['dest'] },
+        dest: { class: 'OptimusPrime::Destinations::MyTestDestination' }
+      )
+    end
+
+    let(:response_body) { File.read('spec/supports/app_annie/one_page_response.json') }
+    let(:response_body_1) { File.read('spec/supports/app_annie/response_1.json') }
+    let(:response_body_2) { File.read('spec/supports/app_annie/response_2.json') }
+
+    def stub_request_app_annie(body, params)
+      stub_request(:get,
+        "https://api.appannie.com/v1.2/accounts/acc_id/products/prod_id/sales?#{params}").
+        with(:headers => {
+          'Accept'=>'*/*; q=0.5, application/xml',
+          'Accept-Encoding'=>'gzip, deflate',
+          'Authorization'=>'Bearer api_key',
+          'User-Agent'=>'Ruby'
+        }).to_return(:status => 200, :body => body, :headers => {})
+    end
+
+    context 'one page response' do
+      it 'returns reponse body' do
+        stub_request_app_annie(response_body,
+          'break_down=date%2Bcountry%2Biap&end_date=2015-01-01&start_date=2015-01-01')
+
+        results = pipeline.start.wait.steps[:dest].written
+        expect(results).to match_array [JSON.parse(response_body)]
+      end
+    end
+
+    context 'multiple pages response' do
+      it 'returns response body' do
+        stub_request_app_annie(response_body_1,
+          'break_down=date%2Bcountry%2Biap&end_date=2015-01-01&start_date=2015-01-01')
+        stub_request_app_annie(response_body_2,
+          'break_down=date%20country%20iap&end_date=2015-01-01&page_index=1&start_date=2015-01-01')
+
+        results = pipeline.start.wait.steps[:dest].written
+        expect(results).to match_array [JSON.parse(response_body_1), JSON.parse(response_body_2)]
+      end
+    end
+  end
+end

--- a/spec/supports/app_annie/one_page_response.json
+++ b/spec/supports/app_annie/one_page_response.json
@@ -1,0 +1,26 @@
+{
+  "sales_list": [
+    {
+      "date": "2015-01-01",
+      "country": "AU",
+      "units": {
+        "product": { "promotions": 0, "downloads": 6, "updates": 22, "refunds": 0 },
+        "iap": { "promotions": 0, "sales": 0, "refunds": 0 }
+      },
+      "revenue": {
+        "product": { "promotions": "0.00", "downloads": "0.00", "updates": "0.00", "refunds": "0.00" },
+        "iap": { "promotions": "0.00", "sales": "0.00", "refunds": "0.00" },
+        "ad": "0.00"
+      }
+    }
+  ],
+  "currency": "USD",
+  "page_index": 0,
+  "market": "ios",
+  "next_page": null,
+  "prev_page": null,
+  "code": 200,
+  "vertical": "apps",
+  "page_num": 1,
+  "iap_sales_list": []
+}

--- a/spec/supports/app_annie/response_1.json
+++ b/spec/supports/app_annie/response_1.json
@@ -1,0 +1,26 @@
+{
+  "sales_list": [
+    {
+      "date": "2015-01-01",
+      "country": "AU",
+      "units": {
+        "product": { "promotions": 0, "downloads": 6, "updates": 22, "refunds": 0 },
+        "iap": { "promotions": 0, "sales": 0, "refunds": 0 }
+      },
+      "revenue": {
+        "product": { "promotions": "0.00", "downloads": "0.00", "updates": "0.00", "refunds": "0.00" },
+        "iap": { "promotions": "0.00", "sales": "0.00", "refunds": "0.00" },
+        "ad": "0.00"
+      }
+    }
+  ],
+  "currency": "USD",
+  "page_index": 0,
+  "market": "ios",
+  "next_page": "/v1.2/accounts/acc_id/products/prod_id/sales?start_date=2015-01-01&end_date=2015-01-01&page_index=1&break_down=date+country+iap",
+  "prev_page": null,
+  "code": 200,
+  "vertical": "apps",
+  "page_num": 2,
+  "iap_sales_list": []
+}

--- a/spec/supports/app_annie/response_2.json
+++ b/spec/supports/app_annie/response_2.json
@@ -1,0 +1,26 @@
+{
+  "sales_list": [
+    {
+      "date": "2015-01-01",
+      "country": "TH",
+      "units": {
+        "product": { "promotions": 0, "downloads": 0, "updates": 0, "refunds": 0 },
+        "iap": { "promotions": 0, "sales": 0, "refunds": 0 }
+      },
+      "revenue": {
+        "product": { "promotions": "0.00", "downloads": "0.00", "updates": "0.00", "refunds": "0.00" },
+        "iap": { "promotions": "0.00", "sales": "0.00", "refunds": "0.00" },
+        "ad": "0.00"
+      }
+    }
+  ],
+  "currency": "USD",
+  "page_index": 1,
+  "market": "ios",
+  "next_page": null,
+  "prev_page": null,
+  "code": 200,
+  "vertical": "apps",
+  "page_num": 2,
+  "iap_sales_list": []
+}


### PR DESCRIPTION
Add ability to retrieve AppAnnie product sales data for a single product.

You have to specify the following arguments:
- api_key
- account_id
- product_id
- start_date
- end_date
