### PR TITLE
Remove “break_down” and add “options” to AppAnnieProductSales#initialize

### DIFF
--- a/lib/optimus_prime/sources/app_annie_product_sales.rb
+++ b/lib/optimus_prime/sources/app_annie_product_sales.rb
@@ -7,12 +7,10 @@ module OptimusPrime
   module Sources
     class AppAnnieProductSales < AppAnnie
       def initialize(api_key:, account_id:, product_id:,
-                     start_date:, end_date:, break_down: 'date+country+iap')
+                     start_date:, end_date:, options: {})
         @api_key = api_key
         @path = "/v1.2/accounts/#{account_id}/products/#{product_id}/sales"
-        @params = {
-          params: { break_down: break_down, start_date: start_date, end_date: end_date }
-        }
+        @params = { params: options.merge(start_date: start_date, end_date: end_date) }
       end
 
       def each

--- a/spec/optimus_prime/sources/app_annie_product_sales_spec.rb
+++ b/spec/optimus_prime/sources/app_annie_product_sales_spec.rb
@@ -27,7 +27,8 @@ describe OptimusPrime::Sources::AppAnnieProductSales do
             account_id: 'acc_id',
             product_id: 'prod_id',
             start_date: '2015-01-01',
-            end_date: '2015-01-01'
+            end_date: '2015-01-01',
+            options: { break_down: 'date+country+iap' }
           }, next: ['dest']
         },
         dest: { class: 'OptimusPrime::Destinations::MyTestDestination' }


### PR DESCRIPTION
Allow users to pass additional parameters, `break_down`, `countries`, and `page_index`, into AppAnnieProductSales class via "options" argument.
