### PR TITLE
Increase timeout to avoid ReadTimeout errors while fetching reports

### DIFF
--- a/lib/optimus_prime/sources/flurry_helpers/flurry_connector.rb
+++ b/lib/optimus_prime/sources/flurry_helpers/flurry_connector.rb
@@ -35,7 +35,11 @@ module OptimusPrime
         # Make the request to Flurry
         def request!
           logger.debug "Fetching report data from #{url}"
-          handle_response(Net::HTTP.get_response(URI(url)))
+          current_url = URI.parse(url)
+          http = Net::HTTP.new(current_url.host, current_url.port)
+          http.read_timeout = 300
+          resp = http.start() { |http| http.get(current_url) }
+          handle_response(resp)
         end
 
         # Check if we're over limit (1 call / second). If we are


### PR DESCRIPTION
The following PR should fix the issue we encountered this morning:

```
playlab@3e68b0934a9f:~/app$ bundle exec optimus operate pipeline pipelines/jungle_cubes/jungle_cubes_flurry_bq_android.yml jungle_cubes_android
Requiring bumblebee
D, [2015-06-04T06:30:36.126859 #29] DEBUG -- : Fetching report data from http://api.flurry.com/rawData/Events?apiAccessCode=26XQNZ3Q6FZTKHB6SV9R&apiKey=FZMYB49QG84NKGJ7NZDF&startTime=1433289600000&endTime=1433376000000
D, [2015-06-04T06:30:36.173869 #29] DEBUG -- : Request Failed. Waiting 1 seconds before retrying.
D, [2015-06-04T06:30:37.174107 #29] DEBUG -- : Fetching report data from http://api.flurry.com/rawData/Events?apiAccessCode=26XQNZ3Q6FZTKHB6SV9R&apiKey=FZMYB49QG84NKGJ7NZDF&startTime=1433289600000&endTime=1433376000000
/usr/local/lib/ruby/2.2.0/net/protocol.rb:158:in `rescue in rbuf_fill': Net::ReadTimeout (Net::ReadTimeout)
    from /usr/local/lib/ruby/2.2.0/net/protocol.rb:152:in `rbuf_fill'
    from /usr/local/lib/ruby/2.2.0/net/protocol.rb:134:in `readuntil'
    from /usr/local/lib/ruby/2.2.0/net/protocol.rb:144:in `readline'
    from /usr/local/lib/ruby/2.2.0/net/http/response.rb:39:in `read_status_line'
    from /usr/local/lib/ruby/2.2.0/net/http/response.rb:28:in `read_new'
    from /usr/local/lib/ruby/2.2.0/net/http.rb:1414:in `block in transport_request'
    from /usr/local/lib/ruby/2.2.0/net/http.rb:1411:in `catch'
    from /usr/local/lib/ruby/2.2.0/net/http.rb:1411:in `transport_request'
    from /usr/local/lib/ruby/2.2.0/net/http.rb:1384:in `request'
    from /usr/local/lib/ruby/2.2.0/net/http.rb:1285:in `request_get'
    from /usr/local/lib/ruby/2.2.0/net/http.rb:480:in `block in get_response'
    from /usr/local/lib/ruby/2.2.0/net/http.rb:853:in `start'
    from /usr/local/lib/ruby/2.2.0/net/http.rb:583:in `start'
    from /usr/local/lib/ruby/2.2.0/net/http.rb:478:in `get_response'
    from /home/playlab/ruby/2.2.0/bundler/gems/optimus-prime-13cedc679351/lib/optimus_prime/sources/flurry_helpers/flurry_connector.rb:38:in `request!'
    from /home/playlab/ruby/2.2.0/bundler/gems/optimus-prime-13cedc679351/lib/optimus_prime/sources/flurry_helpers/flurry_connector.rb:31:in `loop_request'
    from /home/playlab/ruby/2.2.0/bundler/gems/optimus-prime-13cedc679351/lib/optimus_prime/sources/flurry_helpers/flurry_report_generator.rb:21:in `run'
    from /home/playlab/ruby/2.2.0/bundler/gems/optimus-prime-13cedc679351/lib/optimus_prime/sources/flurry.rb:47:in `report_generator'
    from /home/playlab/ruby/2.2.0/bundler/gems/optimus-prime-13cedc679351/lib/optimus_prime/sources/flurry.rb:37:in `report'
    from /home/playlab/ruby/2.2.0/bundler/gems/optimus-prime-13cedc679351/lib/optimus_prime/sources/flurry.rb:26:in `each'
    from /home/playlab/ruby/2.2.0/bundler/gems/optimus-prime-13cedc679351/lib/optimus_prime/source.rb:20:in `block in stream'
    from /home/playlab/ruby/2.2.0/bundler/gems/optimus-prime-13cedc679351/lib/optimus_prime/step.rb:150:in `block in background'
```
