### PR TITLE
JSON Gzipped & Chunked Files

### DIFF
--- a/lib/optimus_prime/streams/file_streams/newline_json_gzipped.rb
+++ b/lib/optimus_prime/streams/file_streams/newline_json_gzipped.rb
@@ -1,0 +1,44 @@
+require 'json'
+require 'zlib'
+
+module OptimusPrime
+  module Streams
+    module FileStreams
+      class NewlineJsonGzipped
+        attr_accessor :logger, :record_count, :file_count, :current_file, :folder
+        attr_reader :folder, :max_per_file
+
+        def initialize(folder, max_per_file)
+          @folder = folder
+          @max_per_file = max_per_file
+          @record_count = 0
+          @file_count = 1
+          @current_file = Zlib::GzipWriter.open(File.join(folder, "#{@file_count}.jgz"))
+        end
+
+        def <<(record)
+          current_file.puts JSON.dump(record)
+          @record_count += 1
+          (@record_count < max_per_file) ? nil : recycle
+        end
+
+        def close
+          complete_file = File.expand_path(current_file.to_io)
+          current_file.close
+          @record_count < 1 ? nil : complete_file
+        end
+
+        private
+
+        def recycle
+          complete_file = File.expand_path(current_file.to_io)
+          current_file.close
+          @record_count = 0
+          @file_count += 1
+          self.current_file = Zlib::GzipWriter.open(File.join(folder, "#{@file_count}.jgz"))
+          complete_file
+        end
+      end
+    end
+  end
+end

--- a/lib/optimus_prime/transformers/file_stream_distributor.rb
+++ b/lib/optimus_prime/transformers/file_stream_distributor.rb
@@ -33,10 +33,10 @@ module OptimusPrime
       private
 
       def push_pair(category, file_path)
-        push({
+        push(
           category: category,
           file: Pathname.new(file_path).relative_path_from(base_path).to_path
-        }) if file_path
+        ) if file_path
       end
 
       def path_for(record)
@@ -44,7 +44,7 @@ module OptimusPrime
       end
 
       def category_of(record)
-        category_template % record
+        (category_template % record).downcase.gsub('.', '_')
       end
 
       def find_or_create_stream(category, record)

--- a/lib/optimus_prime/transformers/file_stream_distributor.rb
+++ b/lib/optimus_prime/transformers/file_stream_distributor.rb
@@ -26,7 +26,7 @@ module OptimusPrime
       def finish
         @streams.each do |category, stream|
           file_path = stream.close
-          push_pair(category, file_path)
+          push_pair(category, file_path) if file_path
         end
       end
 

--- a/lib/optimus_prime/transformers/file_stream_distributor.rb
+++ b/lib/optimus_prime/transformers/file_stream_distributor.rb
@@ -11,7 +11,7 @@ module OptimusPrime
         @path_template = path_template
         @base_path = Pathname.new(base_path)
         @max_per_file = max_per_file
-        @stream_type = stream_type
+        @stream_type = stream_type.is_a?(String) ? constantize(stream_type) : stream_type
         @streams = {}
       end
 
@@ -31,6 +31,10 @@ module OptimusPrime
       end
 
       private
+
+      def constantize(name)
+        name.split('::').reduce(Module, :const_get)
+      end
 
       def push_pair(category, file_path)
         push(

--- a/lib/optimus_prime/transformers/file_stream_distributor.rb
+++ b/lib/optimus_prime/transformers/file_stream_distributor.rb
@@ -1,0 +1,61 @@
+require 'pathname'
+
+module OptimusPrime
+  module Transformers
+    class FileStreamDistributor < Destination
+      attr_reader :category_template, :path_template, :base_path, :max_per_file, :stream_type
+
+      def initialize(path_template:, base_path: '/tmp',
+          category_template:, stream_type:, max_per_file: 1_000_000)
+        @category_template = category_template
+        @path_template = path_template
+        @base_path = Pathname.new(base_path)
+        @max_per_file = max_per_file
+        @stream_type = stream_type
+        @streams = {}
+      end
+
+      def write(original_record)
+        record = original_record.symbolize_keys
+        category = category_of(record)
+        stream = find_or_create_stream(category, record)
+        file_path = stream << original_record
+        push_pair(category, file_path)
+      end
+
+      def finish
+        @streams.each do |category, stream|
+          file_path = stream.close
+          push_pair(category, file_path)
+        end
+      end
+
+      private
+
+      def push_pair(category, file_path)
+        push({
+          category: category,
+          file: Pathname.new(file_path).relative_path_from(base_path).to_path
+        }) if file_path
+      end
+
+      def path_for(record)
+        path_template % record
+      end
+
+      def category_of(record)
+        category_template % record
+      end
+
+      def find_or_create_stream(category, record)
+        unless @streams.key? category
+          folder = Pathname.new(File.join(base_path, path_for(record)))
+          folder.mkpath
+          @streams[category] = stream_type.new(folder.to_path, max_per_file)
+          @streams[category].logger = logger
+        end
+        @streams[category]
+      end
+    end
+  end
+end

--- a/spec/optimus_prime/streams/file_streams/newline_json_gzipped_spec.rb
+++ b/spec/optimus_prime/streams/file_streams/newline_json_gzipped_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+require 'optimus_prime/streams/file_streams/newline_json_gzipped'
+
+RSpec.describe OptimusPrime::Streams::FileStreams::NewlineJsonGzipped do
+  let(:mpf) { 100 }
+  let(:sample) { { 'foo' => 'bar', 'baz' => 'quux' } }
+  let(:stream) { OptimusPrime::Streams::FileStreams::NewlineJsonGzipped.new('/tmp', mpf) }
+  after(:each) { File.delete(*Dir['/tmp/*.jgz']) }
+
+  context 'each chunk' do
+    before :each do
+      @file = mpf.times.map { stream << sample }.compact.first
+      stream.close
+      @gz = Zlib::GzipReader.open(@file)
+    end
+
+    after(:each) { @gz.close }
+
+    it 'is a valid gzip file' do
+      expect { @gz.read }.to_not raise_error
+    end
+
+    it 'is newline delimitered' do
+      content = @gz.read
+      expect(content.lines.length).to be > 1
+    end
+
+    it 'has exactly the expected number of records' do
+      content = @gz.read
+      expect(content.lines.length).to eq mpf
+    end
+
+    it 'contains valid JSON objects' do
+      content = @gz.read
+      expect { content.each_line { |line| JSON.parse(line.strip) } }.to_not raise_error
+    end
+  end
+
+  context 'chunking' do
+    before :each do
+      files = total.times.map { stream << sample }
+      files << stream.close
+      @files = files.compact
+    end
+
+    context 'with the count of all records = max_per_file * X' do
+      let(:total) { 10 * mpf }
+
+      after :each do
+        File.delete(*Dir['*.jgz'])
+      end
+
+      it 'generates X number of files' do
+        expect(@files.length).to eq total / mpf
+      end
+
+      it 'makes each file contain max_per_file records' do
+        @files.each do |file|
+          gz = Zlib::GzipReader.open(file)
+          content = gz.read
+          gz.close
+          expect(content.lines.length).to eq(mpf)
+        end
+      end
+    end
+
+    context 'with the count of all records = (max_per_file * X) + Y' do
+      let(:total) { 10 * mpf + 5 }
+
+      it 'generates X + 1 files' do
+        expect(@files.length).to eq total / mpf + 1
+      end
+
+      it 'makes all files but the last one contain max_per_file records' do
+        @files.first(@files.length - 1).each do |file|
+          gz = Zlib::GzipReader.open(file)
+          content = gz.read
+          gz.close
+          expect(content.lines.length).to eq(mpf)
+        end
+      end
+
+      it 'makes the last file contain Y records' do
+        gz = Zlib::GzipReader.open(@files.last)
+        content = gz.read
+        gz.close
+        expect(content.lines.length).to eq(total % mpf)
+      end
+    end
+  end
+end

--- a/spec/optimus_prime/transformers/file_stream_distributor_spec.rb
+++ b/spec/optimus_prime/transformers/file_stream_distributor_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+require 'optimus_prime/transformers/file_stream_distributor'
+require 'optimus_prime/streams/file_streams/newline_json_gzipped'
+
+RSpec.describe OptimusPrime::Transformers::FileStreamDistributor do
+  let(:max_per_file) { 10 }
+  let(:count_per_cat) { 60 }
+  let(:path_template) { 'optimuspec/jsondistributor/%{Version}' }
+  let(:category_template) { 'sample_%{Version}' }
+  let(:base_path) { '/tmp' }
+  let(:sample) { { 'Event' => 'LevelUp', 'PlayerID' => '123456' } }
+  let(:cat_ver) do
+    { 'sample_1_2_3' => '1.2.3', 'sample_1_0_3' => '1.0.3', 'sample_1_4_5' => '1.4.5' }
+  end
+  let(:input) do
+    count_per_cat.times.map do
+      cat_ver.each.map { |key, value| sample.merge('Version' => value) }
+    end.flatten.shuffle
+  end
+  let(:transformer) do
+    OptimusPrime::Transformers::FileStreamDistributor.new(
+      path_template: path_template, base_path: base_path,
+      category_template: category_template,  max_per_file: max_per_file,
+      stream_type: OptimusPrime::Streams::FileStreams::NewlineJsonGzipped
+    )
+  end
+  after(:each) do
+    p = Pathname.new(File.join(base_path, 'optimuspec'))
+    p.rmtree if p.exist?
+  end
+
+  context 'with invalid data' do
+    it 'raises an error' do
+      output = []
+      transformer.output << output
+      input.sample.delete('Version')
+      expect { input.each { |record| transformer.write(record) } }.to raise_error(KeyError)
+      transformer.close
+    end
+  end
+
+  context 'with valid data' do
+    it 'creates the expected number of files' do
+      output = []
+      transformer.output << output
+      input.each { |record| transformer.write(record) }
+      transformer.close
+      expect(output.compact.length).to eq 18
+    end
+
+    it 'creates the expected number of files per category' do
+      output = []
+      transformer.output << output
+      input.each { |record| transformer.write(record) }
+      transformer.close
+      results = cat_ver.each.map { |k, v| [k, []] }.to_h
+      output.compact.each do |pair|
+        results[pair[:category]] << pair[:file]
+      end
+      results.each do |category, files|
+        expect(files.length).to eq 6
+      end
+    end
+
+    it 'directs records to the correct categories' do
+      output = []
+      transformer.output << output
+      input.each { |record| transformer.write(record) }
+      transformer.close
+      output.compact.each do |pair|
+        category = pair[:category]
+        file = pair[:file]
+        gz = Zlib::GzipReader.open(File.join(base_path, file))
+        content = gz.read
+        gz.close
+        content.each_line do |line|
+          record = JSON.parse(line.strip)
+          expect(record['Version']).to eq cat_ver[category]
+        end
+      end
+    end
+  end
+end

--- a/spec/optimus_prime/transformers/file_stream_distributor_spec.rb
+++ b/spec/optimus_prime/transformers/file_stream_distributor_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe OptimusPrime::Transformers::FileStreamDistributor do
     OptimusPrime::Transformers::FileStreamDistributor.new(
       path_template: path_template, base_path: base_path,
       category_template: category_template,  max_per_file: max_per_file,
-      stream_type: OptimusPrime::Streams::FileStreams::NewlineJsonGzipped
+      stream_type: 'OptimusPrime::Streams::FileStreams::NewlineJsonGzipped'
     )
   end
   after(:each) do


### PR DESCRIPTION
This pull request contains two additions:
1. `NewlineJsonGzipped` class, which stores a stream of JSON objects in one or more gzipped files, each record in a new line. It's configurable so that we can specify how many records go pre file. 
2. The `FileStreamDistributor` transformer/destination, which distributes records to multiple file streams (like `NewlineJsonGzipped`) based on a category template that's filled with data from the record itself.

This pull request is not yet to be merged, there are three things before merging it:
1. The CircleCI build should succeed.
2. I should write some documentation on each class, especially regarding its parameters.
3. The `FileStreamDistributor` should constantize the `stream_type` parameter if it is a string.
