### PR TITLE
Retry on Network Errors

### DIFF
--- a/lib/optimus_prime/destinations/common/bigquery_table_base.rb
+++ b/lib/optimus_prime/destinations/common/bigquery_table_base.rb
@@ -112,7 +112,7 @@ module OptimusPrime
         return response if [200, 404].include?(response.status)
         raise_response(response)
       rescue => e
-        raise e unless (500..599).include?(response.status) and retries < MAX_RETRIES
+        raise e unless response and (500..599).include?(response.status) and retries < MAX_RETRIES
         sleep duration
         duration *= 2
         retries += 1


### PR DESCRIPTION
When a request to BigQuery fails due to something like a network or connection error, the pipeline fails altogether. This pull request will make all BigQuery steps retry when a network error occurs.
