### PR TITLE
AppAnnie user advertising sales

### DIFF
--- a/lib/optimus_prime/sources/app_annie.rb
+++ b/lib/optimus_prime/sources/app_annie.rb
@@ -8,7 +8,7 @@ module OptimusPrime
         url = "https://api.appannie.com#{path}"
         begin
           JSON.parse(
-            RestClient.send(method, url, ({ authorization: "Bearer #{api_key}" }).merge(options))
+            RestClient.send(method, url, { authorization: "Bearer #{api_key}" }.merge(options))
           )
         rescue => e
           raise e.response

--- a/lib/optimus_prime/sources/app_annie_user_advertising_sales.rb
+++ b/lib/optimus_prime/sources/app_annie_user_advertising_sales.rb
@@ -40,7 +40,7 @@ module OptimusPrime
       end
 
       def parameterize(params)
-        URI.escape(params.collect{|k,v| "#{k}=#{v}"}.join('&'))
+        URI.escape(params.collect { |k, v| "#{k}=#{v}" }.join('&'))
       end
     end
   end

--- a/lib/optimus_prime/sources/app_annie_user_advertising_sales.rb
+++ b/lib/optimus_prime/sources/app_annie_user_advertising_sales.rb
@@ -1,5 +1,10 @@
-# The AppAnnieProductSales source retrieves the sales data for a single product.
-#
+# The AppAnnieUserAdvertisingSales source retrieves the user adsvertising sales data from AppAnnie.
+
+# Advertising metrics broken down by ad account, country, app, ad_item and/or date.
+# Data can be filtered by country, ad account and app.
+# The metrics returned will be based on the data breakdown chosen.
+# Breakdown parameter must be provided.
+
 # You can pass optional parameters via "options".
 # For more details see https://support.appannie.com/hc/en-us/articles/204208944-8-User-Advertising-Sales.
 
@@ -8,8 +13,9 @@ module OptimusPrime
     class AppAnnieUserAdvertisingSales < AppAnnie
       def initialize(api_key:, break_down:, options: {})
         @api_key = api_key
-        @path = "/v1.2/ads/sales"
-        @params = { params: options.merge(break_down: break_down) }
+        url_params = parameterize(options.merge(break_down: break_down))
+        @path = "/v1.2/ads/sales?#{url_params}"
+        @params = {}
       end
 
       def each
@@ -31,6 +37,10 @@ module OptimusPrime
             options = {}
           end
         end
+      end
+
+      def parameterize(params)
+        URI.escape(params.collect{|k,v| "#{k}=#{v}"}.join('&'))
       end
     end
   end

--- a/lib/optimus_prime/sources/app_annie_user_advertising_sales.rb
+++ b/lib/optimus_prime/sources/app_annie_user_advertising_sales.rb
@@ -1,0 +1,37 @@
+# The AppAnnieProductSales source retrieves the sales data for a single product.
+#
+# You can pass optional parameters via "options".
+# For more details see https://support.appannie.com/hc/en-us/articles/204208944-8-User-Advertising-Sales.
+
+module OptimusPrime
+  module Sources
+    class AppAnnieUserAdvertisingSales < AppAnnie
+      def initialize(api_key:, break_down:, options: {})
+        @api_key = api_key
+        @path = "/v1.2/ads/sales"
+        @params = { params: options.merge(break_down: break_down) }
+      end
+
+      def each
+        request(method: :get, path: @path, api_key: @api_key, **@params).each do |response|
+          yield response
+        end
+      end
+
+      private
+
+      def request(method:, path:, api_key:, **options)
+        Enumerator.new do |enum|
+          loop do
+            response = super
+            enum << response
+            break unless response['next_page']
+
+            path = response['next_page']
+            options = {}
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/optimus_prime/sources/app_annie_user_advertising_sales_spec.rb
+++ b/spec/optimus_prime/sources/app_annie_user_advertising_sales_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+module OptimusPrime
+  module Destinations
+    class MyTestDestination < Destination
+      attr_reader :written
+      def initialize
+        @written = []
+      end
+
+      def write(record)
+        @written << record
+      end
+    end
+  end
+end
+
+describe OptimusPrime::Sources::AppAnnieUserAdvertisingSales do
+  describe '#each' do
+    let(:pipeline) do
+      OptimusPrime::Pipeline.new(
+        {
+          src: {
+            class: 'OptimusPrime::Sources::AppAnnieUserAdvertisingSales',
+            params: {
+              api_key: 'api_key',
+              break_down: 'ad_account+date',
+              options: {}
+            }, next: ['dest']
+          },
+          dest: { class: 'OptimusPrime::Destinations::MyTestDestination' }
+        },
+        nil, {}, Logger.new('/dev/null')
+      )
+    end
+
+    let(:response_body) { File.read('spec/supports/app_annie/user_ads_sale/uas_response_single_page.json') }
+    let(:response_body_p1) { File.read('spec/supports/app_annie/user_ads_sale/uas_response_multipage_p1.json') }
+    let(:response_body_p2) { File.read('spec/supports/app_annie/user_ads_sale/uas_response_multipage_p2.json') }
+
+    def stub_request_app_annie(body, params)
+      url = "https://api.appannie.com/v1.2/ads/sales?#{params}"
+      stub_request(:get, url).with(
+        headers: {
+          'Accept' => '*/*; q=0.5, application/xml',
+          'Accept-Encoding' => 'gzip, deflate',
+          'Authorization' => 'Bearer api_key',
+          'User-Agent' => 'Ruby'
+        }).to_return(status: 200, body: body, headers: {})
+    end
+
+    context 'one page response' do
+      it 'returns reponse body' do
+        stub_request_app_annie(
+          response_body,
+          'break_down=ad_account%2Bdate'
+        )
+
+        results = pipeline.start.wait.steps[:dest].written
+        expect(results).to match_array [JSON.parse(response_body)]
+      end
+    end
+
+    context 'multiple pages response' do
+      it 'returns response body' do
+        stub_request_app_annie(
+          response_body_p1,
+          'break_down=ad_account%2Bdate'
+        )
+        stub_request_app_annie(
+          response_body_p2,
+          'break_down=ad_account%20date&page_index=1'
+        )
+        results = pipeline.start.wait.steps[:dest].written
+        expect(results).to match_array [JSON.parse(response_body_p1), JSON.parse(response_body_p2)]
+      end
+    end
+  end
+end

--- a/spec/optimus_prime/sources/app_annie_user_advertising_sales_spec.rb
+++ b/spec/optimus_prime/sources/app_annie_user_advertising_sales_spec.rb
@@ -53,7 +53,7 @@ describe OptimusPrime::Sources::AppAnnieUserAdvertisingSales do
       it 'returns reponse body' do
         stub_request_app_annie(
           response_body,
-          'break_down=ad_account%2Bdate'
+          'break_down=ad_account+date'
         )
 
         results = pipeline.start.wait.steps[:dest].written
@@ -65,11 +65,11 @@ describe OptimusPrime::Sources::AppAnnieUserAdvertisingSales do
       it 'returns response body' do
         stub_request_app_annie(
           response_body_p1,
-          'break_down=ad_account%2Bdate'
+          'break_down=ad_account+date'
         )
         stub_request_app_annie(
           response_body_p2,
-          'break_down=ad_account%20date&page_index=1'
+          'break_down=ad_account+date&page_index=1'
         )
         results = pipeline.start.wait.steps[:dest].written
         expect(results).to match_array [JSON.parse(response_body_p1), JSON.parse(response_body_p2)]

--- a/spec/supports/app_annie/user_ads_sale/uas_response_multipage_p1.json
+++ b/spec/supports/app_annie/user_ads_sale/uas_response_multipage_p1.json
@@ -1,0 +1,29 @@
+{
+  "sales_list": [
+    {
+      "product_id": "all",
+      "country": "all",
+      "metric": {
+        "fill_rate": null,
+        "ecpm": 1,
+        "revenue": 1,
+        "impressions": 1000,
+        "requests": 0,
+        "ecpc": 0.01,
+        "clicks": 10
+      },
+      "ad_item_type": "site",
+      "ad_account": 1,
+      "ad_item_id": "all",
+      "date": "2014-01-01",
+      "market": "all"
+    }
+  ],
+  "next_page": "/v1.2/ads/sales?break_down=ad_account+date&page_index=1",
+  "code": 200,
+  "user_id": 1,
+  "prev_page": null,
+  "page_num": 2,
+  "currency": "USD",
+  "page_index": 0
+}

--- a/spec/supports/app_annie/user_ads_sale/uas_response_multipage_p2.json
+++ b/spec/supports/app_annie/user_ads_sale/uas_response_multipage_p2.json
@@ -1,0 +1,29 @@
+{
+  "sales_list": [
+    {
+      "product_id": "all",
+      "country": "all",
+      "metric": {
+        "fill_rate": null,
+        "ecpm": 1,
+        "revenue": 1,
+        "impressions": 1000,
+        "requests": 0,
+        "ecpc": 0.01,
+        "clicks": 10
+      },
+      "ad_item_type": "site",
+      "ad_account": 2,
+      "ad_item_id": "all",
+      "date": "2014-01-01",
+      "market": "all"
+    }
+  ],
+  "next_page": null,
+  "code": 200,
+  "user_id": 1,
+  "prev_page": "/v1.2/ads/sales?break_down=ad_account+date&page_index=1",
+  "page_num": 2,
+  "currency": "USD",
+  "page_index": 1
+}

--- a/spec/supports/app_annie/user_ads_sale/uas_response_single_page.json
+++ b/spec/supports/app_annie/user_ads_sale/uas_response_single_page.json
@@ -1,0 +1,29 @@
+{
+  "sales_list": [
+    {
+      "product_id": "all",
+      "country": "all",
+      "metric": {
+        "fill_rate": null,
+        "ecpm": 1,
+        "revenue": 1,
+        "impressions": 1000,
+        "requests": 0,
+        "ecpc": 0.01,
+        "clicks": 10
+      },
+      "ad_item_type": "site",
+      "ad_account": 1,
+      "ad_item_id": "all",
+      "date": "2014-01-01",
+      "market": "all"
+    }
+  ],
+  "next_page": null,
+  "code": 200,
+  "user_id": 1,
+  "prev_page": null,
+  "page_num": 1,
+  "currency": "USD",
+  "page_index": 0
+}


### PR DESCRIPTION
**PR** Create new source to retrieve the [user advertising sales](https://support.appannie.com/hc/en-us/articles/204208944-8-User-Advertising-Sales) data from AppAnnie.

**Parameters** : Required only `break_down` you can see the optional list at [this link](https://support.appannie.com/hc/en-us/articles/204208944-8-User-Advertising-Sales)
