### PR TITLE
Add ability to extract data from AppAnnie and create new transformation step to change value with key

### DIFF
--- a/lib/optimus_prime/transformers/change_value_with_key.rb
+++ b/lib/optimus_prime/transformers/change_value_with_key.rb
@@ -26,7 +26,7 @@ module OptimusPrime
 
       def change_value(record)
         record.each do |key, value|
-          record[key] = @mapper[key] if @mapper.has_key? key
+          record[key] = @mapper[key] if @mapper.key? key
         end
         record
       end

--- a/lib/optimus_prime/transformers/change_value_with_key.rb
+++ b/lib/optimus_prime/transformers/change_value_with_key.rb
@@ -1,0 +1,36 @@
+module OptimusPrime
+  module Transformers
+    # The ChangeValueWithKey transformer changes values of a Hash with specify key in mapper variable
+    #
+    # to different values based on a mapper.
+    #
+    # Any type of value is supported.
+    # Not matching values stay untouched.
+    #
+    # Example mapper:
+    #
+    # {
+    #   'key1' => 100,
+    #   'key2' => false
+    # }
+    class ChangeValueWithKey < Destination
+      # format_data = [ { key: value } ]
+      def initialize(mapper:)
+        @mapper = mapper.with_indifferent_access
+      end
+
+      def write(record)
+        push change_value(record)
+      end
+
+      private
+
+      def change_value(record)
+        record.each do |key, value|
+          record[key] = @mapper[key] if @mapper.has_key? key
+        end
+        record
+      end
+    end
+  end
+end

--- a/lib/optimus_prime/transformers/change_value_with_key.rb
+++ b/lib/optimus_prime/transformers/change_value_with_key.rb
@@ -14,7 +14,6 @@ module OptimusPrime
     #   'key2' => false
     # }
     class ChangeValueWithKey < Destination
-      # format_data = [ { key: value } ]
       def initialize(mapper:)
         @mapper = mapper.with_indifferent_access
       end

--- a/lib/optimus_prime/transformers/extract_app_annie_data.rb
+++ b/lib/optimus_prime/transformers/extract_app_annie_data.rb
@@ -34,7 +34,7 @@ module OptimusPrime
         if data.is_a? Hash
           data.each { |key, value| set_new_key(new_row, value, "#{prefix}_#{key}") }
         else
-          new_row["#{prefix}"] = data
+          new_row[prefix] = data
         end
         new_row
       end

--- a/lib/optimus_prime/transformers/extract_app_annie_data.rb
+++ b/lib/optimus_prime/transformers/extract_app_annie_data.rb
@@ -1,0 +1,59 @@
+module OptimusPrime
+  module Transformers
+    # This class create for flatten nested json from AppAnnie to single hash.
+    # This class rewrite from ExtractAppAnnieProductSales to make more flexible for "default_fields" and "extract_keys" variables
+      # default_fields: specify whatever fields that you need the data.
+      # extract_keys: specify the nested key to drill down and flatten data into the single hash
+    # See example in spec and PR
+
+    class ExtractAppAnnieData < OptimusPrime::Destination
+      def initialize(default_fields:, extract_keys:)
+        @rows = []
+        @default_fields = default_fields
+        @extract_keys = extract_keys
+      end
+
+      def write(data)
+        extract data
+      end
+
+      def finish
+        @rows.each { |row| push row }
+      end
+
+      private
+
+      def extract(data)
+        @extract_keys.each do |key|
+          extract_list data, key
+        end
+      end
+
+      def expand_hash(data, prefix)
+        new_row = {}
+        if data.is_a? Hash
+          data.each { |key, value| set_new_key(new_row, value, "#{prefix}_#{key}") }
+        else
+          new_row["#{prefix}"] = data
+        end
+        new_row
+      end
+
+      def set_new_key(row, value, key)
+        value.is_a?(Hash) ? value.each { |k, v| row["#{key}_#{k}"] = v } : row[key] = value
+      end
+
+      def default_fields(data)
+        data.select { |k, v| @default_fields.include? k }
+      end
+
+      def extract_list(data, prefix)
+        data[prefix].each do |row|
+          new_row = default_fields(data).merge('sales_type' => prefix)
+          row.each { |key, value| new_row.merge! expand_hash(value, key) }
+          @rows << new_row
+        end
+      end
+    end
+  end
+end

--- a/lib/optimus_prime/transformers/extract_app_annie_data.rb
+++ b/lib/optimus_prime/transformers/extract_app_annie_data.rb
@@ -2,8 +2,8 @@ module OptimusPrime
   module Transformers
     # This class create for flatten nested json from AppAnnie to single hash.
     # This class rewrite from ExtractAppAnnieProductSales to make more flexible for "default_fields" and "extract_keys" variables
-      # default_fields: specify whatever fields that you need the data.
-      # extract_keys: specify the nested key to drill down and flatten data into the single hash
+      # default_fields: chosen key to assign in each hash after flatten.
+      # extract_keys: flatten data inside these key into single hash.
     # See example in spec and PR
 
     class ExtractAppAnnieData < OptimusPrime::Destination

--- a/lib/optimus_prime/transformers/extract_app_annie_data.rb
+++ b/lib/optimus_prime/transformers/extract_app_annie_data.rb
@@ -2,9 +2,9 @@ module OptimusPrime
   module Transformers
     # This class create for flatten nested json from AppAnnie to single hash.
     # This class rewrite from ExtractAppAnnieProductSales to make more flexible for "default_fields" and "extract_keys" variables
-      # default_fields: chosen key to assign in each hash after flatten.
-      # extract_keys: flatten data inside these key into single hash.
-    # See example in spec and PR
+    #   default_fields: chosen key to assign in each hash after flatten.
+    #   extract_keys: flatten data inside these key into single hash.
+    # See example in spec and PR (https://github.com/pocket-playlab/optimus-prime/pull/25)
 
     class ExtractAppAnnieData < OptimusPrime::Destination
       def initialize(default_fields:, extract_keys:)

--- a/spec/optimus_prime/transformers/change_value_with_key_spec.rb
+++ b/spec/optimus_prime/transformers/change_value_with_key_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+RSpec.describe OptimusPrime::Transformers::ChangeValueWithKey do
+  let(:mapper) do
+    {
+      'keyA' => 100,
+      'keyB' => 200,
+      'keyC' => 'string',
+      'keyD' => true
+    }
+  end
+
+  let(:input) do
+    [
+      {
+        'keyA' => nil,
+        'keyB' => 500,
+        'untouch' => 'not change'
+      },
+      {
+        'keyA' => 200,
+        'keyC' => 100,
+        'keyD' => false,
+        'untouch' => 'not change'
+      }
+    ]
+  end
+
+  let(:output) do
+    [
+      {
+        'keyA' => 100,
+        'keyB' => 200,
+        'untouch' => 'not change'
+      },
+      {
+        'keyA' => 100,
+        'keyC' => 'string',
+        'keyD' => true,
+        'untouch' => 'not change'
+      }
+    ]
+  end
+
+  context 'map with different data types' do
+    it 'changes everything correctly' do
+      step = OptimusPrime::Transformers::ChangeValueWithKey.new(mapper: mapper)
+      expect(step.run_with(input)).to match_array output
+    end
+  end
+end

--- a/spec/optimus_prime/transformers/extract_app_annie_data_spec.rb
+++ b/spec/optimus_prime/transformers/extract_app_annie_data_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe OptimusPrime::Transformers::ExtractAppAnnieData do
+  let(:basepath) { 'app_annie' }
+  let(:step) { OptimusPrime::Transformers::ExtractAppAnnieData.new(
+      default_fields: [ 'vertical', 'currency', 'market' ],
+      extract_keys: ['sales_list', 'iap_sales_list']
+    )
+  }
+
+  context 'input contains both sales_list and iap_sales_list from multiple pages' do
+    let(:input)  { load_json("#{basepath}/input_multiple.json")  }
+    let(:output) { load_json("#{basepath}/output_multiple.json") }
+
+    it 'returns an array of extracted data' do
+      expect(step.run_with(input)).to match_array output
+    end
+  end
+
+  context 'input contains only sales_list from one page' do
+    let(:input)  { load_json("#{basepath}/input_sales_list.json")  }
+    let(:output) { load_json("#{basepath}/output_sales_list.json") }
+
+    it 'returns an array of extracted data' do
+      expect(step.run_with(input)).to match_array output
+    end
+  end
+
+  context 'input contains only iap_sales_list from one page' do
+    let(:input)  { load_json("#{basepath}/input_iap_sales_list.json")  }
+    let(:output) { load_json("#{basepath}/output_iap_sales_list.json") }
+
+    it 'returns an array of extracted data' do
+      expect(step.run_with(input)).to match_array output
+    end
+  end
+end


### PR DESCRIPTION
# PR

This PR create for flatten nested JSON from AppAnnie to single hash. `ExtractAppAnnieData` class is rewrite from `ExtractAppAnnieProductSales`.It's add the ability to config `default_fields` and `extract_keys` variables via pipeline.
# Params explanation

  `default_fields` : chosen key to assign in each hash after flatten.
  `extract_keys` : flatten data inside these key into single hash.
# Example

**Pipeline config**

```
default_fields = ['level1D']
extract_keys = ['level1A']
```

This mean I need to extract the data inside `level1A` key into multiple single hash and added `level1D` in each hash.

**Input**

```
{
    "level1A": [
      {
        "level2A": "valueA",
        "level2B": {
          "level3": "valueA"
        }
      },
      {
        "level2A": "valueB",
        "level2B": {
          "level3": "valueB"
        }
      }
    ],
    "level1B": "nil",
    "level1C": 200,
    "level1D": 1
 }
```

**Output is ...**

```
{
    "level2A": "valueA",
    "level2B_level3": "valueA",
    "sales_type": "level1A",
    "level1D": 1
},
{
    "level2A": "valueB",
    "level2B_level3": "valueB",
    "sales_type": "level1A",
    "level1D": 1
}
```
