### PR TITLE
Changed geotransformer to not raise exception on invalid ip

### DIFF
--- a/lib/optimus_prime/transformers/geoip_lookup.rb
+++ b/lib/optimus_prime/transformers/geoip_lookup.rb
@@ -56,13 +56,13 @@ module OptimusPrime
 
       def write(record)
         record[@geo_field_name] = {}
-        record = get_geoip record if check_valid_ip record[@ip_field]
+        record = get_geoip record if ip_valid? record[@ip_field]
         push record
       end
 
       private
 
-      def check_valid_ip(ip)
+      def ip_valid?(ip)
         if @ip_regex.match(ip)
           true
         else

--- a/lib/optimus_prime/transformers/geoip_lookup.rb
+++ b/lib/optimus_prime/transformers/geoip_lookup.rb
@@ -47,6 +47,7 @@ module OptimusPrime
         @db_file = maxmind_db_file
         @gz_db_file = '/tmp/GeoLite2-City.mmdb.gz'
         @geo_field_name = 'geographic_info'
+        @ip_regex = Regexp.new('\d+{1,3}\.\d+{1,3}\.\d+{1,3}\.\d+{1,3}')
 
         download_database maxmind_db_url unless File.exist?(@db_file)
 
@@ -54,10 +55,21 @@ module OptimusPrime
       end
 
       def write(record)
-        push get_geoip record
+        record[@geo_field_name] = {}
+        record = get_geoip record if check_valid_ip record[@ip_field]
+        push record
       end
 
       private
+
+      def check_valid_ip(ip)
+        if @ip_regex.match(ip)
+          true
+        else
+          logger.error("Invalid IP Address [#{ip}]")
+          false
+        end
+      end
 
       def get_geoip(record)
         result = @db.lookup(record[@ip_field])
@@ -70,7 +82,6 @@ module OptimusPrime
       end
 
       def add_fields(result, record)
-        record[@geo_field_name] = {}
         record = add_city result, record
         record = add_postal result, record
         record = add_location result, record

--- a/spec/optimus_prime/transformers/geoip_lookup_spec.rb
+++ b/spec/optimus_prime/transformers/geoip_lookup_spec.rb
@@ -28,6 +28,36 @@ RSpec.describe OptimusPrime::Transformers::GeoIP do
     ]
   end
 
+  let(:invalid_ip_address_output) do
+    [
+      {
+        'name' => 'test',
+        'ip_addr' => 'iamnotanipaddress',
+        'geographic_info' => {}
+      }
+    ]
+  end
+
+  let(:private_ip_address_input) do
+    [
+      {
+        'name' => 'test',
+        'ip_addr' => '192.168.0.1'
+      }
+    ]
+  end
+
+  let(:private_ip_address_output) do
+    [
+      {
+        'name' => 'test',
+        'ip_addr' => '192.168.0.1',
+        'geographic_info' => {}
+      }
+    ]
+  end
+
+
   let(:success_output) do
     [
       {
@@ -69,15 +99,17 @@ RSpec.describe OptimusPrime::Transformers::GeoIP do
     end
   end
 
-  context 'valid geoip lookup' do
-    it 'adds geographic_info field with lookup values' do
+  context 'geoip lookup' do
+    it 'valid ip adds geographic_info field with lookup values' do
       expect(step.run_with(valid_input)).to match_array success_output
     end
-  end
-
-  context 'invalid ip address geoip lookup' do
-    it 'raises an exception' do
-      expect { step.run_and_raise(invalid_ip_address_input) }.to raise_error IPAddr::InvalidAddressError
+    it 'invalid ip adds an empty geographic_info field and logs error' do
+      expect(step.run_with(invalid_ip_address_input)).to match_array invalid_ip_address_output
+      expect(File.read(logfile).lines.count).to be > 1
+    end
+    it 'private ip adds an empty geographic_info field and logs error' do
+      expect(step.run_with(private_ip_address_input)).to match_array private_ip_address_output
+      expect(File.read(logfile).lines.count).to be > 1
     end
   end
 end


### PR DESCRIPTION
Geographic transformer will not longer raise an exception on an invalid IP address. Now if an invalid ip is encountered it will log an error and return empty geographic information.
