### PR TITLE
Reduced the size of the no GeoIP found exception

### DIFF
--- a/lib/optimus_prime/transformers/geoip_lookup.rb
+++ b/lib/optimus_prime/transformers/geoip_lookup.rb
@@ -76,7 +76,7 @@ module OptimusPrime
         if result.found?
           record = add_fields result, record
         else
-          logger.error("No GeoIP result found - #{record}")
+          logger.error("No GeoIP result found [#{record[@ip_field]}]")
         end
         record
       end


### PR DESCRIPTION
Due to a large amount of invalid IPs in the old datasets I've decided to make the size of the invalid IP exception to be shorter. Previously it was outputting the entire record. Now it will only output the invalid IP address within the exception message.
