### PR TITLE
Added Environment variable to Sentry logs

### DIFF
--- a/lib/optimus_prime/modules/exceptional/adapters/sentry_adapter.rb
+++ b/lib/optimus_prime/modules/exceptional/adapters/sentry_adapter.rb
@@ -15,6 +15,9 @@ module OptimusPrime
 
           def configure_errors_adapter(&block)
             ::Raven.configure do |config|
+              config.tags = {
+                environment: ENV.fetch('SENTRY_ENVIRONMENT', 'unknown')
+              }
               block.call(config)
             end
           end


### PR DESCRIPTION
In order to tell where an exception is coming from, I've added a environment tag to the Sentry logs. This tag is set via the environment variable `SENTRY_ENVIRONMENT`.

In Sentry you will see under the Tags section there is an `environment = staging` tag.
